### PR TITLE
Fix duplicated items in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,6 @@
       - eamodio.gitlens
       - ms-toolsai.jupyter
       - ms-vsliveshare.vsliveshare
-      - njqdev.vscode-python-typehint
       - EricSia.pythonsnippets3
       - congyiwu.vscode-jupytext
       - streetsidesoftware.code-spell-checker-russian


### PR DESCRIPTION
Fixes #15 

### Что сделано
- Удалены дублирующиеся пункты в README.md

### Причина
В текущей версии README.md некоторые пункты повторяются, что ухудшает читаемость документации.

Closes #15 

